### PR TITLE
Fix blockquote example

### DIFF
--- a/content/cheatsheet/extend-markdown/blockquote.md
+++ b/content/cheatsheet/extend-markdown/blockquote.md
@@ -7,6 +7,6 @@ The `blockquote` default function.
 
 ```js
 Marked.blockquote = ( quote ) => {
-  return `<blockquote>\n${ + quote + }</blockquote>\n`;
+  return `<blockquote>\n${ quote }</blockquote>\n`;
 }
 ```


### PR DESCRIPTION
I noticed that there is a confusing `+ quote +` inside the template literals. This can probably just be `quote`.